### PR TITLE
Merge branch 'Android scoped paths fix' into 'main'

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,46 +58,23 @@ Copy the folder 'mpv-progress-sync' to /hom:e/USERNAME/.config/mpv/scripts
   - The location of the mpv scripts folder when installing manually (e.g. not using Scoop) is normally: C:\Users\USERNAME\AppData\Roaming\mpv\scripts\
 
 ### Android
-
-- NOTE: Since Android version 12 Google has restricted access to the data folder where the files need to be placed so please see the guide below
-
 #### Installation guide (non-rooted)
-
-- In the Google Play Store install the files app by Marc apps & software [Files app (Play Store)](https://play.google.com/store/apps/details?id=com.marc.files)
-
-- Open the files App and navigate to /storage/emulated/0/Android/data/is.xyz.mpv/files/
-- In this folder create the folders .config->mpv->scripts
-
-  - The folder structure will look like this:
-    Android
-    data
-    is.xyz.mpv
-    files
-    .config
-    mpv
-    scripts
-
+- Open your files App and navigate to /storage/emulated/0/Android/media/is.xyz.mpv/
 - Clone this repository or Copy the folder 'mpv-progress-sync' to your phone (any location)
-- NOTE: Using the Files App you will only be able to copy the files initially to the 'Android' folder
 - Open the Files app and select the 'mpv-sync-progress' folder. Select the three dots on the top right and select 'copy to'
-- Copy the folder to the 'Android' folder
-- Then in the Files app open the Android folder
-- You should now be able to see the 'data' folder
-- Drag each Lua file from the 'Android' folder into data->is.xyz.mpv->files->.config->mpv->scripts
-- [General video tutorial of using the Files app with the data folder](https://www.youtube.com/watch?v=HGzRx_HxrmQ)
+- Copy the folder to /storage/emulated/0/Android/media/is.xyz.mpv/
 
 - Open mpv-android
   - Press back button once
   - Go to Settings -> Advanced -> edit mpv.conf
-  - add the following: script="/storage/emulated/0/Android/data/is.xyz.mpv/files/.config/mpv/scripts/mpv-progress-sync/main.lua"
+  - add the following: script="/storage/emulated/0/Android/media/is.xyz.mpv/mpv-progress-sync/main.lua"
 
 #### Installation guide (Rooted)
-
-- Copy the folder mpv-progress-sync' to Android->data->is.xyz.mpv->files->.config->mpv->scripts
+- Copy the folder mpv-progress-sync' to Android->media->is.xyz.mpv
 - Open mpv-android
   - Press back button once
   - Go to Settings->Advanced - edit mpv.conf
-  - add the following: script="/storage/emulated/0/Android/data/is.xyz.mpv/files/.config/mpv/scripts/mpv-progress-sync/main.lua"
+  - add the following: script="/storage/emulated/0/Android/media/mpv-progress-sync/main.lua"
 
 ## Dependencies / Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ A cross platform script to save a files position when using mpv or mpv android a
 
 ## Background
 
-- mpv does have save position option which can be set by adding '--save-position-on-quit' to mpv.conf
-- However the issue is that the way in which this is carried out is specific to where the location was stored.
-- If you have 'file.mp4' in your /home/Downloads folder and you also have 'file.mp4' in /home/Documents when you play the first file and then re-open the second file the progress will not be up to date
-  - The progress is stored for each of these two files
-- This also means that saving the location across devices will not work (due to the hashing process mpv uses to store the file location and name)
+- mpv does have an option to the save position option which can be set by adding '--save-position-on-quit' to mpv.conf
+- However the issue is that the way in which this is stored  is specific to where the location was stored.
+    - If you open the 'file.mp4' in mpv which is in your /home/Downloads folder and move the same file to /home/Documents, when you open this file again  the progress will not be up to date
+        - The progress is stored for each of these two files
+        - This also means that saving the location across devices will not work (due to the hashing process mpv uses to store the file location and name)
 
-- This script solves this problem by only using the filename being opened
-- The script stores the names of the files being opened using a hashing process so the names of the saved location files are private
+- This script solves this problem by only using the combination of the files size and duration of the opened file
+- The script stores the names of this combination using a hashing process so the names of the saved location files are private
 - Note: To sync across devices you need to use an appropriate sync program. You can synchronise your different devices folders that store your media files progress in mpv that store your save positions using sync services such as [Syncthing](https://syncthing.net/)
   - This allows you to sync your progress of a media file in mpv very easily
 
@@ -35,7 +35,7 @@ A cross platform script to save a files position when using mpv or mpv android a
 
 ### Linux or Mac
 
-Copy the folder 'mpv-progress-sync' to /hom:e/USERNAME/.config/mpv/scripts
+Copy the folder 'mpv-progress-sync' to /home/USERNAME/.config/mpv/scripts
 
 ### Windows
 

--- a/mpv-progress-sync/main.lua
+++ b/mpv-progress-sync/main.lua
@@ -40,7 +40,7 @@ mp.register_event("file-loaded", function()
         -- Set folder to save position of files and the script folder location itself
         android_position_folder = "/storage/emulated/0/Android/media/is.xyz.mpv/mpv-positions/"
         android_script_folder =
-        '/storage/emulated/0/Android/data/is.xyz.mpv/files/.config/mpv/scripts/mpv-progress-sync/lib/'
+        '/storage/emulated/0/Android/media/is.xyz.mpv/mpv-progress-sync/lib/'
         -- Import decoder from from lunajson , call loadFile to open the file and then create a new decoder object
         decoder_file = android_script_folder .. 'decoder.lua'
         newdecoder = loadfile(decoder_file)()
@@ -108,7 +108,9 @@ mp.register_event("shutdown", function()
     -- If the position is not nill and it is greater than 2 seconds 
     if position ~= nil and position > 2 then
         -- Sanitise the filename to remove escape characters
+        print("Temp filename 1: ",filename)
         filename = string.gsub(filename, "[^%w%.%-_]", "_")
+        print("Temp filename 2: ",filename)
         -- Get current OS
         myos = getOS()
 
@@ -121,6 +123,8 @@ mp.register_event("shutdown", function()
         -- Create the filepath to save the position 
         filepath = folder .. filename .. ".json"
         -- Open tthe file 
+
+        print("Saving filepath: ",filepath)
         positionFile, err = io.open(filepath, "w")
         if not positionFile then
             print("Error opening file to write:", err)
@@ -162,7 +166,7 @@ function getFilename(myos)
     end
     if myos == "Android" or myos == "Toybox" then
         md5 = loadFile(
-            '/storage/emulated/0/Android/data/is.xyz.mpv/files/.config/mpv/scripts/mpv-progress-sync/lib/md5.lua')
+            '/storage/emulated/0/Android/media/is.xyz.mpv/mpv-progress-sync/lib/md5.lua')
     end
     if myos == "Windows" then
         md5 = loadFile(os.getenv("USERPROFILE") ..
@@ -170,8 +174,17 @@ function getFilename(myos)
     end
     -- Get the title of the opened file in mpv
     title = mp.get_property("media-title")
+    print("Original title: ",title)
+    local filename = mp.get_property("filename")
+    print("Temp title 1: ",filename)
+    local stream_filename = mp.get_property("stream-open-filename")
+    print("Temp title 2: ",stream_filename)
+    local meta_title = mp.get_property("metadata/by-key/title")
+    print("Temp title 3: ",meta_title)
+
     -- Use the md5 function to create a hash of the filename 
     title = md5.sumhexa(title)
+    print("Hashed title: ",title)
     -- Return the hashed title
     return title
 end

--- a/mpv-progress-sync/main.lua
+++ b/mpv-progress-sync/main.lua
@@ -1,4 +1,4 @@
--- Global variables ysed in different functions, so have to be declared globally
+-- Global variables below are used in different functions, so have to be declared globally
 filepath = ''
 folder = ''
 duration = 0
@@ -108,9 +108,7 @@ mp.register_event("shutdown", function()
     -- If the position is not nill and it is greater than 2 seconds 
     if position ~= nil and position > 2 then
         -- Sanitise the filename to remove escape characters
-        print("Temp filename 1: ",filename)
         filename = string.gsub(filename, "[^%w%.%-_]", "_")
-        print("Temp filename 2: ",filename)
         -- Get current OS
         myos = getOS()
 
@@ -172,21 +170,15 @@ function getFilename(myos)
         md5 = loadFile(os.getenv("USERPROFILE") ..
             '\\scoop\\apps\\mpv\\current\\portable_config\\scripts\\mpv-progress-sync\\lib\\md5.lua')
     end
-    -- Get the title of the opened file in mpv
-    title = mp.get_property("media-title")
-    print("Original title: ",title)
-    local filename = mp.get_property("filename")
-    print("Temp title 1: ",filename)
-    local stream_filename = mp.get_property("stream-open-filename")
-    print("Temp title 2: ",stream_filename)
-    local meta_title = mp.get_property("metadata/by-key/title")
-    print("Temp title 3: ",meta_title)
-
+    -- Get the file size and duration of the opened file in mpv
+    local file_size = mp.get_property_number("file-size")
+    local duration = mp.get_property_number("duration")
+    -- Add the combination of the values together and convert to a string
+    local file_descriptor = tostring(file_size + duration)
     -- Use the md5 function to create a hash of the filename 
-    title = md5.sumhexa(title)
-    print("Hashed title: ",title)
-    -- Return the hashed title
-    return title
+    local fd = md5.sumhexa(file_descriptor)
+    -- Return the hashed file descriptor
+    return fd
 end
 
 


### PR DESCRIPTION
The positioning functionality of this script now works correctly. Due to some limitations of mpv-android the filename could not be used to create the hash of an open files title in mpv as it runs in a sandbox. To resolve this I refactored the script to use the combination of a files size and duration in mpv in order to track the position